### PR TITLE
feat: add Supabase edge functions and clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,57 @@ Stack: Next.js (App Router) + TypeScript + Supabase (Auth/DB/Storage) + RLS.
 3. `npm i` y luego `npm run dev`.
 
 Estructura base con rutas protegidas y helpers de Supabase.
+
+## Funciones Edge y clientes Supabase
+
+### Variables de entorno
+
+#### Web (`.env.local`)
+```
+NEXT_PUBLIC_SUPABASE_URL=tu_url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=tu_anon_key
+```
+
+#### Móvil (`mobile/.env` o `app.config`)
+```
+EXPO_PUBLIC_SUPABASE_URL=tu_url
+EXPO_PUBLIC_SUPABASE_ANON_KEY=tu_anon_key
+```
+
+### Uso en la web (Next.js)
+- `lib/edge.ts` expone `callEdge` que firma la petición con el token activo del usuario.
+- `hooks/useApproveOvertime.ts` y `hooks/useGenerateReport.ts` consumen las funciones `approve-overtime` y `generate-report`.
+
+```tsx
+const { approve, loading } = useApproveOvertime()
+await approve(overtimeId)
+```
+
+```tsx
+const { generateReport } = useGenerateReport()
+const { report } = await generateReport({ startDate, endDate })
+```
+
+### Uso en móvil (Expo/React Native)
+- `mobile/lib/supabase.ts` crea el cliente con las variables `EXPO_PUBLIC_*`.
+- `mobile/lib/edge.ts` replica `callEdge` para móvil.
+- Hooks equivalentes en `mobile/hooks/`.
+
+```ts
+const { approve } = useApproveOvertime()
+await approve(overtimeId)
+```
+
+```ts
+const { generateReport } = useGenerateReport()
+const { report } = await generateReport({ startDate, endDate })
+```
+
+### Despliegue de funciones Edge
+```
+supabase login
+supabase link --project-ref <project>
+supabase secrets set SUPABASE_SERVICE_ROLE=<service_role_key>
+supabase functions deploy approve-overtime
+supabase functions deploy generate-report
+```

--- a/hooks/useApproveOvertime.ts
+++ b/hooks/useApproveOvertime.ts
@@ -1,0 +1,25 @@
+'use client'
+import { useState, useCallback } from 'react'
+import { callEdge } from '@/lib/edge'
+
+type ApproveResponse = { ok: true }
+
+export function useApproveOvertime() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const approve = useCallback(async (overtimeId: number) => {
+    setLoading(true); setError(null)
+    try {
+      const res = await callEdge<ApproveResponse>('approve-overtime', { overtimeId })
+      return res
+    } catch (e: any) {
+      setError(e.message || 'Error')
+      throw e
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  return { approve, loading, error }
+}

--- a/hooks/useGenerateReport.ts
+++ b/hooks/useGenerateReport.ts
@@ -1,0 +1,32 @@
+'use client'
+import { useState, useCallback } from 'react'
+import { callEdge } from '@/lib/edge'
+
+type ReportResponse = { ok: true, report: any }
+
+type ReportParams = {
+  startDate: string
+  endDate: string
+  userId?: string
+  area?: string
+}
+
+export function useGenerateReport() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const generateReport = useCallback(async (params: ReportParams) => {
+    setLoading(true); setError(null)
+    try {
+      const res = await callEdge<ReportResponse>('generate-report', params)
+      return res
+    } catch (e: any) {
+      setError(e.message || 'Error')
+      throw e
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  return { generateReport, loading, error }
+}

--- a/lib/edge.ts
+++ b/lib/edge.ts
@@ -1,0 +1,17 @@
+import { supabaseBrowser } from '@/lib/supabase/client-browser'
+
+export async function callEdge<T = unknown>(fn: string, body?: unknown): Promise<T> {
+  const supabase = supabaseBrowser()
+  const { data: { session } } = await supabase.auth.getSession()
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/${fn}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {})
+    },
+    body: body ? JSON.stringify(body) : undefined
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json() as Promise<T>
+}

--- a/mobile/hooks/useApproveOvertime.ts
+++ b/mobile/hooks/useApproveOvertime.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react'
+import { callEdge } from '../lib/edge'
+
+type ApproveResponse = { ok: true }
+
+export function useApproveOvertime() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const approve = useCallback(async (overtimeId: number) => {
+    setLoading(true); setError(null)
+    try {
+      const res = await callEdge<ApproveResponse>('approve-overtime', { overtimeId })
+      return res
+    } catch (e: any) {
+      setError(e.message || 'Error')
+      throw e
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  return { approve, loading, error }
+}

--- a/mobile/hooks/useGenerateReport.ts
+++ b/mobile/hooks/useGenerateReport.ts
@@ -1,0 +1,31 @@
+import { useState, useCallback } from 'react'
+import { callEdge } from '../lib/edge'
+
+type ReportResponse = { ok: true, report: any }
+
+type ReportParams = {
+  startDate: string
+  endDate: string
+  userId?: string
+  area?: string
+}
+
+export function useGenerateReport() {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const generateReport = useCallback(async (params: ReportParams) => {
+    setLoading(true); setError(null)
+    try {
+      const res = await callEdge<ReportResponse>('generate-report', params)
+      return res
+    } catch (e: any) {
+      setError(e.message || 'Error')
+      throw e
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  return { generateReport, loading, error }
+}

--- a/mobile/lib/edge.ts
+++ b/mobile/lib/edge.ts
@@ -1,0 +1,16 @@
+import { supabase } from './supabase'
+
+export async function callEdge<T = unknown>(fn: string, body?: unknown): Promise<T> {
+  const { data: { session } } = await supabase.auth.getSession()
+
+  const res = await fetch(`${process.env.EXPO_PUBLIC_SUPABASE_URL}/functions/v1/${fn}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {})
+    },
+    body: body ? JSON.stringify(body) : undefined
+  })
+  if (!res.ok) throw new Error(await res.text())
+  return res.json() as Promise<T>
+}

--- a/mobile/lib/supabase.ts
+++ b/mobile/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+export const supabase = createClient(
+  process.env.EXPO_PUBLIC_SUPABASE_URL!,
+  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!
+)

--- a/supabase/functions/approve-overtime/index.ts
+++ b/supabase/functions/approve-overtime/index.ts
@@ -1,0 +1,64 @@
+// supabase/functions/approve-overtime/index.ts
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+  });
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  try {
+    const authHeader = req.headers.get("Authorization") ?? "";
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_ANON_KEY")!,
+      { global: { headers: { Authorization: authHeader } } }
+    );
+
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return json({ error: "Unauthorized" }, 401);
+
+    const { data: profile, error: profileErr } = await supabase
+      .from("profiles").select("role").eq("id", user.id).single();
+    if (profileErr) return json({ error: profileErr.message }, 400);
+    if (profile?.role !== "boss") return json({ error: "Forbidden" }, 403);
+
+    const body = await req.json();
+    const overtimeId = Number(body?.overtimeId);
+    if (!overtimeId) return json({ error: "Missing overtimeId" }, 400);
+
+    const service = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE")!
+    );
+    const approvedAt = new Date().toISOString();
+
+    const { error: updErr } = await service
+      .from("overtime")
+      .update({ approved_by: user.id, approved_at: approvedAt })
+      .eq("id", overtimeId);
+    if (updErr) return json({ error: updErr.message }, 400);
+
+    await service.from("audit_log").insert({
+      actor: user.id,
+      action: "approve_overtime",
+      entity: "overtime",
+      entity_id: String(overtimeId),
+      payload: { approved_at: approvedAt },
+    });
+
+    return json({ ok: true });
+  } catch (e) {
+    return json({ error: String(e?.message ?? e) }, 500);
+  }
+});

--- a/supabase/functions/generate-report/index.ts
+++ b/supabase/functions/generate-report/index.ts
@@ -1,0 +1,74 @@
+// supabase/functions/generate-report/index.ts
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+  });
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  try {
+    const authHeader = req.headers.get("Authorization") ?? "";
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_ANON_KEY")!,
+      { global: { headers: { Authorization: authHeader } } }
+    );
+
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return json({ error: "Unauthorized" }, 401);
+
+    const { data: profile, error: profileErr } = await supabase
+      .from("profiles").select("role, area, full_name").eq("id", user.id).single();
+    if (profileErr) return json({ error: profileErr.message }, 400);
+
+    if (!['boss','hr','coordinator'].includes(profile.role)) {
+      return json({ error: "Forbidden" }, 403);
+    }
+
+    const { startDate, endDate, userId, area } = await req.json();
+
+    let query = supabase.from("shifts")
+      .select("id, user_id, work_date, total_minutes")
+      .gte("work_date", startDate)
+      .lte("work_date", endDate);
+
+    if (profile.role === "coordinator") {
+      const { data: usersInArea } = await supabase.from("profiles").select("id").eq("area", profile.area);
+      const ids = (usersInArea ?? []).map(r => r.id);
+      query = query.in("user_id", ids.length ? ids : ["00000000-0000-0000-0000-000000000000"]);
+    }
+
+    if (userId) query = query.eq("user_id", userId);
+    if (area && profile.role !== "coordinator") {
+      const { data: usersInArea } = await supabase.from("profiles").select("id").eq("area", area);
+      const ids = (usersInArea ?? []).map(r => r.id);
+      query = query.in("user_id", ids.length ? ids : ["00000000-0000-0000-0000-000000000000"]);
+    }
+
+    const { data: rows, error } = await query;
+    if (error) return json({ error: error.message }, 400);
+
+    return json({
+      ok: true,
+      report: {
+        range: { startDate, endDate },
+        count: rows?.length ?? 0,
+        items: rows ?? [],
+        report_url: null
+      }
+    });
+  } catch (e) {
+    return json({ error: String(e?.message ?? e) }, 500);
+  }
+});


### PR DESCRIPTION
## Summary
- add Supabase edge functions for approving overtime and generating reports with authorization and logging
- provide shared edge caller plus React hooks for web and Expo mobile apps
- document environment variables, usage patterns, and deployment steps in the README

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/GestorHorasExtra/lint)*

------
https://chatgpt.com/codex/tasks/task_e_690ca0f014a4832989672fd92e920a4f